### PR TITLE
Fix dynamic boss vars for The Ox and The Wheel

### DIFF
--- a/UI_Def append.lua
+++ b/UI_Def append.lua
@@ -48,9 +48,7 @@ function UnBlind_create_UIBox_blind(type) -- Main definition for the whole of th
 	G.GAME.orbital_choices[G.GAME.round_resets.ante][type] = pseudorandom_element(_poker_hands, pseudoseed('orbital'))
 	end
 
-	if type == 'Small' then
-		extras = UnBlind_create_UIBox_blind_tag(type)
-	elseif type == 'Big' then
+	if type == 'Small' or type == 'Big' then
 		extras = UnBlind_create_UIBox_blind_tag(type)
 	else
 		extras = {n=G.UIT.R, config={id = 'tag_container', align = "cm"}, nodes={
@@ -61,9 +59,7 @@ function UnBlind_create_UIBox_blind(type) -- Main definition for the whole of th
 	end
 
 	G.GAME.round_resets.blind_ante = G.GAME.round_resets.blind_ante or G.GAME.round_resets.ante
-	local loc_target = localize{type = 'raw_descriptions', key = blind_choice.config.key, set = 'Blind', vars = UnBlind_get_blind_vars(blind_choice.config)}
 	local loc_name = localize{type = 'name_text', key = blind_choice.config.key, set = 'Blind'}
-	local text_table = loc_target
 	local blind_col = get_blind_main_colour(G.GAME.round_resets.blind_choices[type])
 	local blind_amt = get_blind_amount(G.GAME.round_resets.blind_ante)*blind_choice.config.mult*G.GAME.starting_params.ante_scaling
 
@@ -71,7 +67,9 @@ function UnBlind_create_UIBox_blind(type) -- Main definition for the whole of th
 	local _reward = true
 
 	if G.GAME.modifiers.no_blind_reward and G.GAME.modifiers.no_blind_reward[type] then _reward = nil end
-	if blind_state == 'Select' then blind_state = 'Current' end
+	if blind_state == 'Select' then
+		blind_state = 'Current'
+	end
 	local run_info_colour = run_info and (blind_state == 'Defeated' and G.C.GREY or blind_state == 'Skipped' and mix_colours(G.C.BLUE, G.C.GREY, 0.5) or blind_state == 'Upcoming' and G.C.ORANGE or G.C.GOLD)
 	local blind_state_text_colour =  (blind_state == 'Defeated' and G.C.UI.BACKGROUND_LIGHT or   blind_state == 'Skipped' and G.C.UI.BACKGROUND_LIGHT or blind_state == 'Upcoming' and G.C.WHITE or G.C.GOLD)
 
@@ -178,13 +176,25 @@ function UnBlind_create_UIBox_blind_popup(blind, vars, blind_col) --definition f
 	local blind_text = {}
 
 	local _dollars = blind.dollars
-	local loc_target = localize{type = 'raw_descriptions', key = blind.key, set = 'Blind', vars = UnBlind_get_blind_vars(blind)}
+
+	-- Build target table (new SMODS pattern)
+	local target = {type = 'raw_descriptions', key = blind.key, set = 'Blind', vars = UnBlind_get_blind_vars(blind)}
+	if blind.collection_loc_vars and type(blind.collection_loc_vars) == 'function' then
+		local res = blind:collection_loc_vars() or {}
+		target.vars = res.vars or target.vars
+		target.key = res.key or target.key
+		target.set = res.set or target.set
+		target.scale = res.scale
+		target.text_colour = res.text_colour
+	end
+	local set_tbl = G.localization.descriptions[target.set]
+	local loc_target = set_tbl and set_tbl[target.key] and set_tbl[target.key].text_parsed
 	local loc_name = localize{type = 'name_text', key = blind.key, set = 'Blind'}
 
 	local ability_text = {}
 	if loc_target then
 		for k, v in ipairs(loc_target) do
-			ability_text[#ability_text + 1] = {n=G.UIT.R, config={align = "cm"}, nodes={{n=G.UIT.T, config={text = v, scale = 0.35, shadow = true, colour = G.C.WHITE}}}}
+			ability_text[#ability_text + 1] = {n=G.UIT.R, config={align = "cm"}, nodes=SMODS.localize_box(v, {default_col = target.text_colour or G.C.WHITE, shadow = true, vars = target.vars or {}, scale = target.scale})}
 		end
 	end
 	 local stake_sprite = get_stake_sprite(G.GAME.stake or 1, 0.4)

--- a/lovely.toml
+++ b/lovely.toml
@@ -49,19 +49,6 @@ match_indent = true
 
 
 
-[[patches]]           ##### LETS CRYPTID WORK. Will not need if my pull request on cryptid is accepted
-[patches.pattern]
-target = "functions/misc_functions.lua"
-pattern = '''function localize(args, misc_cat)
-if args and args.vars then
-'''
-position = "at"
-payload = '''function localize(args, misc_cat)
-if args and args.vars and type(args.vars) == "table" then
-'''
-match_indent = true 
-
-
 [[patches]]
 [patches.copy]
 target = "functions/UI_definitions.lua"

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
 	"display_name": "uB",
 	"version": "1.0.0",
 	"dependencies": [
-		"Steamodded (>=1.*)"
+		"Steamodded (>=0.9.8)"
 	],
 	"conflicts": [
 	]


### PR DESCRIPTION
Fixes #13 – The Wheel boss blind text was incorrectly showing the most played hand instead of probability

## Original fix (dynamic boss vars)

- Fixed a bug where The Wheel displayed incorrect text (showing most_played_poker_hand instead of probability)
- Fixed a bug where The Ox was incorrectly mixing with The Wheel's variables
- Added `UnBlind_get_blind_vars()` helper to handle dynamic boss variables:
  - The Ox: uses `most_played_poker_hand` from the current round
  - The Wheel: uses `probabilities.normal` and 7 for n/7 probability display
  - Other bosses: use their default variables from config

## Additional fixes (SMODS 1.0.0-beta-1501a compatibility)

- **Fixed crash in shop blind panel**: SMODS `blind_ui.toml` Patch 3 was injecting `ipairs(text_table)` into `UnBlind_create_UIBox_blind` where `text_table` is nil. Fixed by splitting the single-line `if blind_state == 'Select'` guard into a multi-line block so the pattern match no longer triggers.
- **Rewrote popup localization**: switched from `localize{type='raw_descriptions', ...}` to direct `G.localization.descriptions` + `SMODS.localize_box`, matching the SMODS 1.0 API for rendered description nodes. Supports custom blinds via `collection_loc_vars`.
- **Removed Cryptid compat patch**: the `localize()` monkey-patch in `lovely.toml` is no longer needed and conflicted with SMODS 1.0.
- **Fixed `manifest.json` mod_name**: corrected `unBlindShopGUI` → `UnBlind`.