### PR TITLE
Newer Steamodded versions compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
 	"display_name": "uB",
 	"version": "1.0.0",
 	"dependencies": [
-		"Steamodded (>=0.9.8)"
+		"Steamodded (>=1.*~)"
 	],
 	"conflicts": [
 	]


### PR DESCRIPTION
Updated the steamodded dependency requirements in manifest.json as to not incorrectly say the steamodded version is incompatible.

Credits to @DarkAutumn2618 for suggesting the fix.